### PR TITLE
LibCompiler, C++: use 'jmp' when returning from a function.

### DIFF
--- a/dev/LibCompiler/src/CPlusPlusCompilerAMD64.cc
+++ b/dev/LibCompiler/src/CPlusPlusCompilerAMD64.cc
@@ -15,7 +15,7 @@
 #define kExitNO (EXIT_FAILURE)
 
 #define kSplashCxx() \
-	kPrintF(kWhite "%s\n", "NeKernel C++ Compiler Driver, (c) 2024 Amlal El Mahrouss, all rights reserved.")
+	kPrintF(kWhite "%s\n", "NeKernel Optimized C++ Compiler Driver, (c) 2024-2025 Amlal El Mahrouss, All rights reserved.")
 
 // extern_segment, @autodelete { ... }, fn foo() -> auto { ... }
 
@@ -830,7 +830,7 @@ Boolean CompilerFrontendCPlusPlus::Compile(std::string		 text,
 						std::stringstream ss;
 						ss << it->second;
 
-						syntax_tree.fUserValue = "mov rax, " + ss.str() + "\nret\n";
+						syntax_tree.fUserValue = "jmp " + ss.str() + "\nret\n";
 						kOrigin += 1UL;
 						break;
 					}

--- a/dev/LibCompiler/src/DynamicLinkerPEF.cc
+++ b/dev/LibCompiler/src/DynamicLinkerPEF.cc
@@ -31,7 +31,7 @@
 #include <LibCompiler/NFC/AE.h>
 #include <cstdint>
 
-#define kLinkerVersionStr "NeKernel 64-Bit Linker (Preferred Executable) %s, (c) Amlal El Mahrouss 2024-2025, all rights reserved.\n"
+#define kLinkerVersionStr "\e[0;97m NeKernel 64-Bit Linker (Preferred Executable) %s, (c) Amlal El Mahrouss 2024-2025, all rights reserved.\n"
 
 #define MemoryCopy(DST, SRC, SZ) memcpy(DST, SRC, SZ)
 #define StringCompare(DST, SRC)	 strcmp(DST, SRC)
@@ -39,16 +39,14 @@
 #define kPefNoCpu	 0U
 #define kPefNoSubCpu 0U
 
-#define kWhite "\e[0;97m"
-
-#define kStdOut (std::cout << kWhite << "ld64 (PEF): ")
+#define kStdOut (std::cout << "\e[0;31m" << "ld64: " << "\e[0;97m")
 
 #define kLinkerDefaultOrigin kPefBaseOrigin
 #define kLinkerId			 (0x5046FF)
 #define kLinkerAbiContainer	 "Container:ABI:"
 
 #define kPrintF			printf
-#define kLinkerSplash() kPrintF(kWhite kLinkerVersionStr, kDistVersion)
+#define kLinkerSplash() kPrintF(kLinkerVersionStr, kDistVersion)
 
 /// @brief PEF stack size symbol.
 #define kLinkerStackSizeSymbol "__PEFSizeOfReserveStack"
@@ -104,10 +102,10 @@ LIBCOMPILER_MODULE(DynamicLinker64PEF)
 		{
 			kLinkerSplash();
 
-			kStdOut << "--ld64:ver: Show linker version.\n";
-			kStdOut << "--ld64:?: Show linker help.\n";
+			kStdOut << "--ld64:version: Show linker version.\n";
+			kStdOut << "--ld64:help: Show linker help.\n";
 			kStdOut << "--ld64:verbose: Enable linker trace.\n";
-			kStdOut << "--ld64:dylib: Output as a Dylib PEF.\n";
+			kStdOut << "--ld64:dylib: Output as a Dyanmic PEF.\n";
 			kStdOut << "--ld64:fat: Output as a FAT PEF.\n";
 			kStdOut << "--ld64:32k: Output as a 32x0 PEF.\n";
 			kStdOut << "--ld64:64k: Output as a 64x0 PEF.\n";

--- a/tests/example.cc
+++ b/tests/example.cc
@@ -3,12 +3,13 @@
 
 int bar()
 {
-	int yyy = 5050505055;
+	int yyy = 100;
 	return yyy;
 }
 
 int foo()
 {
+	int arg1 = 0;
 	return bar();
 }
 


### PR DESCRIPTION
# Brief:

Don't put `pc` on `rax`, instead jump from that `pc`.